### PR TITLE
Clean up ORM initlization and extend test cases

### DIFF
--- a/go/gorm/model/models.go
+++ b/go/gorm/model/models.go
@@ -2,24 +2,24 @@ package model
 
 // Customer is a model in the "customers" table.
 type Customer struct {
-	ID   int
-	Name *string `gorm:"not null"`
+	ID   int     `json:"id"`
+	Name *string `json:"name" gorm:"not null"`
 }
 
 // Order is a model in the "orders" table.
 type Order struct {
-	ID       int
-	Subtotal float64 `gorm:"type:decimal(18,2)"`
+	ID       int     `json:"id"`
+	Subtotal float64 `json:"subtotal" gorm:"type:decimal(18,2)"`
 
-	Customer   Customer `gorm:"ForeignKey:CustomerID"`
+	Customer   Customer `json:"customer" gorm:"ForeignKey:CustomerID"`
 	CustomerID int      `json:"-"`
 
-	Products []Product `gorm:"many2many:order_products"`
+	Products []Product `json:"products" gorm:"many2many:order_products"`
 }
 
 // Product is a model in the "products" table.
 type Product struct {
-	ID    int
-	Name  *string `gorm:"not null;unique"`
-	Price float64 `gorm:"type:decimal(18,2)"`
+	ID    int     `json:"id"`
+	Name  *string `json:"name"  gorm:"not null;unique"`
+	Price float64 `json:"price" gorm:"type:decimal(18,2)"`
 }


### PR DESCRIPTION
This change cleans up ORM initialization by pinging the application's HTTP
interface until a connection is successfully established. The change also
extends the ORM test harness' test cases, further testing object creation
and server restart. Finally, it parallelizes subtests where possible.

Dependent on https://github.com/cockroachdb/cockroach-go/pull/24.