### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cockroach ORM examples
 
 This repo contains example uses of CockroachDB with popular ORMs.
-Each example will implement the [sample application](#sample-app) 
-spec presented below. 
+Each example will implement the [sample application](#sample-app)
+spec presented below.
 
 See the [CockroachDB ORM Compatibility Plan](https://docs.google.com/a/cockroachlabs.com/spreadsheets/d/17A0EflPqI9yhargK0n4tSw2WogQuVc5YeK-VFmKvXHM/edit?usp=sharing)
 for a roadmap towards supporting various ORMs.
@@ -26,10 +26,10 @@ make test COCKROACH_BINARY=/path/to/binary/cockroach
 
 The repository contains a set of directories named after programming
 languages. Beneath these language directories are sub-directories
-named after specific ORM used for example application implementations. 
+named after specific ORM used for example application implementations.
 
-Each ORM example uses whatever build tool is standard for the language, 
-but provides a standardized Makefile with a `start` rule, which will 
+Each ORM example uses whatever build tool is standard for the language,
+but provides a standardized Makefile with a `start` rule, which will
 start an instance of the sample application.
 
 For instance, the directory structure for an example application of the
@@ -45,11 +45,11 @@ java
 ## Sample App
 
 The sample application which each example implements is a [JSON REST API](#json-api)
-modeling a **company** with **customers, products, and orders**. The API 
+modeling a **company** with **customers, products, and orders**. The API
 exposes access to the management of this company.
 
-The purpose of the example application is to test common data access patterns 
-so that we can stress various features and implementation details of each 
+The purpose of the example application is to test common data access patterns
+so that we can stress various features and implementation details of each
 language/ORM.
 
 ### Schema
@@ -60,7 +60,7 @@ An ideal schema diagram for the sample application looks like:
 Customer
   |
   v
-Order  <->  Product 
+Order  <->  Product
 ```
 
 The schema is implemented by each application using ORM-specific constructs to look as
@@ -95,24 +95,46 @@ CREATE TABLE IF NOT EXISTS product_orders (
 
 ### JSON API
 
-Each example will expose a RESTful JSON API with the following endpoints:
+Each example will expose a RESTful JSON API. The endpoints and example `curl`
+command lines are:
 
 ```
 GET    /customer
+    curl http://localhost:6543/customer
+
 GET    /customer/:id
+    curl http://localhost:6543/customer/1
+
 POST   /customer
-PUT    /customer
+    curl -X POST -d '{"id": 1, "name": "bob"}' http://localhost:6543/customer
+
+PUT    /customer/:id
+    curl -X PUT -d '{"id": 2, "name": "robert"}' http://localhost:6543/customer/1
+
 DELETE /customer
+    curl -X DELETE http://localhost:6543/customer/1
 
 GET    /product
+    curl http://localhost:6543/customer
+
 GET    /product/:id
+    curl http://localhost:6543/customer/1
+
 POST   /product
+    curl -X POST -d '{"id": 1, "name": "apple", "price": 0.30}' http://localhost:6543/product
+
 PUT    /product
 DELETE /product
 
 GET    /order
+    curl http://localhost:6543/order
+
 GET    /order/:id
+    curl http://localhost:6543/order/1
+
 POST   /order
+    curl -X POST -d '{"id": 1, "subtotal": 18.2, "customer": {"id": 1}}' http://localhost:6543/order
+
 PUT    /order
 DELETE /order
 ```


### PR DESCRIPTION
* Add `curl` command-line examples to README.md
* Return an error in `getJSON`/`postJSON` upon HTTP error
* Print stderr when ORM app is killed using `killCmd`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/10)
<!-- Reviewable:end -->
