### PR TITLE
Various bug fixes

### DIFF
--- a/go/gorm/server.go
+++ b/go/gorm/server.go
@@ -45,7 +45,7 @@ func (s *Server) RegisterRouter(router *httprouter.Router) {
 }
 
 func (s *Server) ping(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	writeTextResult(w, "pong")
+	writeTextResult(w, "go/gorm")
 }
 
 func (s *Server) getCustomers(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/java/hibernate/Makefile
+++ b/java/hibernate/Makefile
@@ -30,4 +30,4 @@ start:
 
 .PHONY: deps
 deps:
-	$(GRADLE) assemble
+	$(GRADLE) assemble --stacktrace

--- a/java/hibernate/src/main/java/com/cockroachlabs/services/PingService.java
+++ b/java/hibernate/src/main/java/com/cockroachlabs/services/PingService.java
@@ -10,7 +10,7 @@ public class PingService {
     @GET
     @Produces("text/plain")
     public String ping() {
-        return "pong";
+        return "java/hibernate";
     }
 
 }


### PR DESCRIPTION
* Return language/orm (e.g. `python/sqlalchemy`) in /ping response.
  This ensures that we're talking to the server we think we're talking
  to.
* When killing an ORM test server, wait for its listen port to
  disappear. In particular, the Hibernate app takes ~10 seconds to
  disappear, which was causing back-to-back `make test` runs to fail.
  Also, this was causing Python tests (to follow in a separate PR) to
  fail because the Hibernate app returns 500 errors while it's shutting
  down.
* Pipe `stderr` for ORM apps to `os.Stderr` and a buffer that can be
  checked for errors. Hidden errors have caused me lots of grief.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/12)
<!-- Reviewable:end -->
