### PR TITLE
Add SQLAlchemy (Python) test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Cockroach Authors.
+# Copyright 2017 The Cockroach Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,3 +47,4 @@ dockergitclean:
 deps:
 	$(GO) get -d -t ./...
 	$(MAKE) deps -C ./java/hibernate
+	$(MAKE) deps -C ./python/sqlalchemy

--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -1,0 +1,26 @@
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+
+ADDR ?= cockroachdb://root@localhost:26257/company_sqlalchemy?sslmode=disable
+
+.PHONY: start
+start:
+	ADDR=$(ADDR) ./server.py --port=6543
+
+.PHONY: deps
+deps:
+	# To avoid permissions errors, the following should be run in a virtualenv
+	# (preferred) or as root.
+	pip install flask-sqlalchemy cockroachdb

--- a/python/sqlalchemy/models.py
+++ b/python/sqlalchemy/models.py
@@ -1,0 +1,64 @@
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+
+from flask_sqlalchemy import SQLAlchemy
+import json
+
+db = SQLAlchemy()
+
+
+# Customer maps to the "customers" table.
+class Customer(db.Model):
+    __tablename__ = 'customers'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, nullable=True)
+
+    def as_dict(self):
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
+
+# Order maps to the "orders" table.
+class Order(db.Model):
+    __tablename__ = 'orders'
+    id = db.Column(db.Integer, primary_key=True)
+    subtotal = db.Column(db.DECIMAL(18, 2))
+
+    #customer = db.relationship('customer', backref=db.backref('posts', lazy='dynamic'))
+    customer_id = db.Column(db.Integer, db.ForeignKey('customers.id'))
+
+    def as_dict(self):
+        return {
+            'id': self.id,
+            'subtotal': str(self.subtotal),
+            'customer_id': self.customer_id,
+        }
+
+
+# Product maps to the "products" table.
+class Product(db.Model):
+    __tablename__ = 'products'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, nullable=False, unique=True)
+    price = db.Column(db.DECIMAL(18, 2))
+
+    def as_dict(self):
+        return {'id': self.id, 'name': self.name, 'price': str(self.price)}
+
+
+# order_products_table is a many-to-many table mapping Orders to Products.
+order_products_table = db.Table(
+    'order_products', db.metadata,
+    db.Column('order_id', db.Integer, db.ForeignKey('orders.id')),
+    db.Column('product_id', db.Integer, db.ForeignKey('products.id')))

--- a/python/sqlalchemy/server.cfg
+++ b/python/sqlalchemy/server.cfg
@@ -1,0 +1,17 @@
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+
+# Suppress an annoying warning.
+SQLALCHEMY_TRACK_MODIFICATIONS = True

--- a/python/sqlalchemy/server.py
+++ b/python/sqlalchemy/server.py
@@ -1,0 +1,173 @@
+#! /usr/bin/env python
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+
+from __future__ import print_function
+
+# Import Flask code.
+from flask import Flask, Response, request
+
+# Import SQLAlchemy code.
+from flask_sqlalchemy import SQLAlchemy
+import sqlalchemy.orm
+
+# This import isn't actually referenced directly below but is included to
+# clearly indicate whether the CockroachDB dialect is missing.
+import cockroachdb
+
+from models import db, Customer, Order, Product
+
+import argparse
+from decimal import Decimal
+import json
+import logging
+import os
+
+DEFAULT_URL = "cockroachdb://root@localhost:26257/company_sqlalchemy?sslmode=disable"
+
+# Setup and return Flask app.
+def setup_app():
+    # Setup Flask app.
+    app = Flask(__name__)
+    app.config.from_pyfile('server.cfg')
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("ADDR", DEFAULT_URL)
+    app.debug = False
+
+    # Disable log messages, which are outputted to stderr and treated as errors
+    # by the test driver.
+    if not app.debug:
+        logging.getLogger('werkzeug').setLevel(logging.ERROR)
+
+    # Initialize flask-sqlachemy.
+    db.init_app(app)
+    with app.test_request_context():
+        db.create_all()
+
+    return app
+
+app = setup_app()
+
+
+@app.route('/ping')
+def ping():
+    return 'python/sqlalchemy'
+
+
+# The following functions respond to various HTTP routes, as described in the
+# top-level README.md.
+
+@app.route('/customer', methods=['GET'])
+def get_customers():
+    customers = [c.as_dict() for c in Customer.query.all()]
+    return Response(json.dumps(customers), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+@app.route('/customer', methods=['POST'])
+def create_customer():
+    try:
+        body = request.stream.read().decode('utf-8')
+        data = json.loads(body)
+        customer = Customer(id=data.get('id'), name=data['name'])
+        db.session.add(customer)
+        db.session.commit()
+    except (ValueError, KeyError) as e:
+        return Response(str(e), 400)
+    return body
+
+
+@app.route('/customer/<id>', methods=['GET'])
+def get_customer(id=None):
+    if id is None:
+        return Response('no ID specified', 400)
+    customer = db.session.query(Customer).get(int(id))
+    return Response(json.dumps(customer.as_dict()), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+@app.route('/order', methods=['GET'])
+def get_orders():
+    orders = [o.as_dict() for o in Order.query.all()]
+    return Response(json.dumps(orders), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+@app.route('/order', methods=['POST'])
+def create_order():
+    try:
+        body = request.stream.read().decode('utf-8')
+        data = json.loads(body)
+        order = Order(
+            id=data.get('id'),
+            subtotal=Decimal(data['subtotal']),
+            customer_id=data['customer']['id'])
+        db.session.add(order)
+        db.session.commit()
+    except (ValueError, KeyError) as e:
+        return Response(str(e), 400)
+    return body
+
+
+@app.route('/order/<id>', methods=['GET'])
+def get_order(id=None):
+    if id is None:
+        return Response('no ID specified', 400)
+    order = db.session.query(Order).get(int(id))
+    return Response(json.dumps(order.as_dict()), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+@app.route('/product', methods=['GET'])
+def get_products():
+    products = [p.as_dict() for p in Product.query.all()]
+    return Response(json.dumps(products), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+@app.route('/product', methods=['POST'])
+def create_product():
+    try:
+        body = request.stream.read().decode('utf-8')
+        data = json.loads(body)
+        product = Product(id=data.get('id'), name=data['name'], price=Decimal(data['price']))
+        db.session.add(product)
+        db.session.commit()
+    except (ValueError, KeyError) as e:
+        return Response(str(e), 400)
+    return body
+
+
+@app.route('/product/<id>', methods=['GET'])
+def get_product(id=None):
+    if id is None:
+        return Response('no ID specified', 400)
+    product = db.session.query(Product).get(int(id))
+    return Response(json.dumps(product.as_dict()), 200,
+                    mimetype="application/json; charset=UTF-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Test SQLAlchemy compatibility with CockroachDB.')
+    parser.add_argument('--port', dest='port', type=int,
+                        help='server listen port', default=6543)
+    args = parser.parse_args()
+    print('listening on port %d' % args.port)
+    app.run(host='localhost', port=args.port)
+
+
+if __name__ == '__main__':
+    main()

--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -36,6 +36,12 @@ func (app application) dbName() string {
 	return fmt.Sprintf("company_%s", app.orm)
 }
 
+// customURLSchemes contains custom schemes for database URLs that are needed
+// for test apps that rely on a custom ORM dialect.
+var customURLSchemes = map[application]string{
+	application{language: "python", orm: "sqlalchemy"}: "cockroachdb",
+}
+
 // initTestDatabase launches a test database as a subprocess.
 func initTestDatabase(t *testing.T, app application) (*sql.DB, *url.URL, func()) {
 	ts, err := testserver.NewTestServer()
@@ -65,6 +71,9 @@ func initTestDatabase(t *testing.T, app application) (*sql.DB, *url.URL, func())
 		t.Fatal(err)
 	}
 
+	if scheme, ok := customURLSchemes[app]; ok {
+		url.Scheme = scheme
+	}
 	return db, url, func() {
 		_ = db.Close()
 		ts.Stop()
@@ -227,4 +236,8 @@ func TestGORM(t *testing.T) {
 
 func TestHibernate(t *testing.T) {
 	testORM(t, "java", "hibernate")
+}
+
+func TestSQLAlchemy(t *testing.T) {
+	testORM(t, "python", "sqlalchemy")
 }


### PR DESCRIPTION
This uses Flask & flask-sqlalchemy to test SQLAlchemy compatibility
with CockroachDB using our custom database dialect.

Tested with Python 2.7.12 and 3.5.2. How to make this run in our test environment is a separate issue that I'll also have to tackle soon.

cc @nvanbenschoten

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/13)
<!-- Reviewable:end -->
