### PR TITLE
Add `dockertest` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 # Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
 
 GO ?= go
+POSTGRES_TEST_TAG ?= 20170227-1358
 
 .PHONY: all
 all: test
@@ -28,6 +29,12 @@ endif
 test:
 	$(GO) test -v -i ./testing
 	$(GO) test -v ./testing $(BINARYFLAG)
+
+.PHONY: dockertest
+dockertest:
+	docker run --volume="$(shell pwd)":/examples-orms \
+		"cockroachdb/postgres-test:$(POSTGRES_TEST_TAG)" \
+		make -C /examples-orms deps test
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
This Makefile target runs the ORM tests in a `postgres-test` container,
which has the required language-specific tools. This is to prep for the
Python tests, which needs `pip`, which is already installed in
`postgres-test`.

Relies on cockroachdb/postgres-test#18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/14)
<!-- Reviewable:end -->
