### PR TITLE
Bugfixes and improvements

### DIFF
--- a/go/gorm/model/models.go
+++ b/go/gorm/model/models.go
@@ -9,7 +9,7 @@ type Customer struct {
 // Order is a model in the "orders" table.
 type Order struct {
 	ID       int     `json:"id,omitempty"`
-	Subtotal float64 `json:"subtotal" gorm:"type:decimal(18,2)"`
+	Subtotal float64 `json:"subtotal,string" gorm:"type:decimal(18,2)"`
 
 	Customer   Customer `json:"customer" gorm:"ForeignKey:CustomerID"`
 	CustomerID int      `json:"-"`
@@ -21,5 +21,5 @@ type Order struct {
 type Product struct {
 	ID    int     `json:"id,omitempty"`
 	Name  *string `json:"name"  gorm:"not null;unique"`
-	Price float64 `json:"price" gorm:"type:decimal(18,2)"`
+	Price float64 `json:"price,string" gorm:"type:decimal(18,2)"`
 }

--- a/go/gorm/model/models.go
+++ b/go/gorm/model/models.go
@@ -2,13 +2,13 @@ package model
 
 // Customer is a model in the "customers" table.
 type Customer struct {
-	ID   int     `json:"id"`
+	ID   int     `json:"id,omitempty"`
 	Name *string `json:"name" gorm:"not null"`
 }
 
 // Order is a model in the "orders" table.
 type Order struct {
-	ID       int     `json:"id"`
+	ID       int     `json:"id,omitempty"`
 	Subtotal float64 `json:"subtotal" gorm:"type:decimal(18,2)"`
 
 	Customer   Customer `json:"customer" gorm:"ForeignKey:CustomerID"`
@@ -19,7 +19,7 @@ type Order struct {
 
 // Product is a model in the "products" table.
 type Product struct {
-	ID    int     `json:"id"`
+	ID    int     `json:"id,omitempty"`
 	Name  *string `json:"name"  gorm:"not null;unique"`
 	Price float64 `json:"price" gorm:"type:decimal(18,2)"`
 }

--- a/java/hibernate/src/main/java/com/cockroachlabs/model/Order.java
+++ b/java/hibernate/src/main/java/com/cockroachlabs/model/Order.java
@@ -1,5 +1,8 @@
 package com.cockroachlabs.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 import javax.persistence.*;
 import java.math.BigDecimal;
 import java.util.Set;
@@ -14,6 +17,7 @@ public class Order {
     private long id;
 
     @Column(name="subtotal", precision=18, scale=2)
+    @JsonSerialize(using = ToStringSerializer.class)
     private BigDecimal subtotal;
 
     @ManyToOne

--- a/java/hibernate/src/main/java/com/cockroachlabs/model/Product.java
+++ b/java/hibernate/src/main/java/com/cockroachlabs/model/Product.java
@@ -1,5 +1,8 @@
 package com.cockroachlabs.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 import javax.persistence.*;
 import java.math.BigDecimal;
 import java.util.Set;
@@ -17,6 +20,7 @@ public class Product {
     private String name;
 
     @Column(name="price", precision=18, scale=2)
+    @JsonSerialize(using = ToStringSerializer.class)
     private BigDecimal price;
 
     @ManyToMany(cascade=CascadeType.ALL, mappedBy="products")

--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -120,9 +120,6 @@ func initORMApp(t *testing.T, app application, dbURL *url.URL) (killFunc, restar
 		killCmd()
 		t.Fatalf("error waiting for http server initialization: %v stderr=%s", err, stderr.String())
 	}
-	if s := stderr.String(); len(s) > 0 {
-		killCmd()
-	}
 
 	restartCmd := func() (killFunc, restartFunc) {
 		killCmd()

--- a/testing/test_driver.go
+++ b/testing/test_driver.go
@@ -23,8 +23,8 @@ var (
 	customerName1 = "Billy"
 
 	productName1       = "Ice Cream"
-	productPrice1      = "123.4"
-	productPrice1Float = 123.4
+	productPrice1      = "123.40"
+	productPrice1Float = 123.40
 )
 
 // parallelTestGroup maps a set of names to test functions, and will run each
@@ -184,7 +184,7 @@ func (td testDriver) TestCreateOrder(t *testing.T) {
 	if err := td.api.createOrder(customerID, productID, productPrice1Float); err != nil {
 		t.Fatalf("error creating order: %v", err)
 	}
-	td.queryAndAssert(t, []string{row(productPrice1Float)}, fmt.Sprintf(`SELECT subtotal FROM %s`, ordersTable))
+	td.queryAndAssert(t, []string{row(productPrice1)}, fmt.Sprintf(`SELECT subtotal FROM %s`, ordersTable))
 }
 
 func (td testDriver) TestRetrieveCustomerAfterCreation(t *testing.T) {


### PR DESCRIPTION
This fixes the failures against newer versions of Cockroach, which now correctly respect decimal precisions.

Also,
- the tests no longer send empty id values when posting new entities
- the tests no longer care if an ORM created extra tables for bookkeeping (which ActiveRecord does, for example)
- the tests don't fail even if there is some output on stderr from the server under test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/16)
<!-- Reviewable:end -->
