### PR TITLE
Wait until test app server port becomes available

### DIFF
--- a/testing/api_handler.go
+++ b/testing/api_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 
@@ -28,6 +29,15 @@ const (
 // for convenient JSON marshalling/unmarshalling, but this format should be the same
 // across all ORMs.
 type apiHandler struct{}
+
+func (apiHandler) canDial() bool {
+	conn, err := net.Dial("tcp", applicationAddr)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
 
 func (apiHandler) ping(expected string) error {
 	resp, err := http.Get(pingPath)

--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -90,6 +90,19 @@ func initORMApp(app application, dbURL *url.URL) (func() error, error) {
 		if err := cmd.Wait(); err.Error() != "signal: "+syscall.SIGKILL.String() {
 			return err
 		}
+
+		// Killing a process is not instant. For example, with the Hibernate server,
+		// it often takes ~10 seconds for the listen port to become available after
+		// this function is called. This is despite the above code that issues a
+		// SIGKILL to the process group for the test server.
+		for {
+			if !(apiHandler{}).canDial() {
+				break
+			}
+			log.Printf("waiting for app server port to become available")
+			time.Sleep(time.Second)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
When killing a test app, it can take about 10 seconds (for Hibernate)
to release the server port. This results in issues like this:

```
2017/03/13 14:05:44 listen tcp :6543: bind: address already in use
make[1]: *** [start] Error 1
```

The easiest way to trigger this is to run `make && make`. This
reinstates a removed test that ensures that the listen port (6543) is
available before moving on to the next group of tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/18)
<!-- Reviewable:end -->
