### PR TITLE
teach docker not to create directories as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+docker_root
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@
 # Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
 
 GO ?= go
-POSTGRES_TEST_TAG ?= 20170308-1644
-DOCKER_GOPATH = /root/go
-DOCKER_REPO_PATH = $(DOCKER_GOPATH)/src/github.com/cockroachdb/examples-orms
-DOCKER = docker run --volume="$(shell go env GOPATH | cut -f1 -d:)/src":$(DOCKER_GOPATH)/src docker.io/cockroachdb/postgres-test:$(POSTGRES_TEST_TAG)
 
 .PHONY: all
 all: test
@@ -36,14 +32,7 @@ test:
 
 .PHONY: dockertest
 dockertest: godeps
-		$(DOCKER) make -C $(DOCKER_REPO_PATH) ormdeps test $(DOCKERFLAG)
-
-# Run `git clean` in Docker to remove leftover files that are owned by root.
-# This must be run after `dockertest` to ensure that successive CI runs don't
-# fail.
-.PHONY: dockergitclean
-dockergitclean:
-		$(DOCKER) /bin/bash -c "cd $(DOCKER_REPO_PATH) && git clean -f -d -x ."
+	./docker.sh make ormdeps test $(DOCKERFLAG)
 
 .PHONY: deps
 deps: godeps ormdeps

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+#
+# Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+# This file is largely cargo-culted from cockroachdb/cockroach/build/builder.sh.
+
+set -euo pipefail
+
+image=docker.io/cockroachdb/postgres-test:20170308-1644
+
+gopath=$(go env GOPATH)
+gopath0=${gopath%%:*}
+
+# Absolute path to this repository.
+repo_root=$(cd "$(dirname "${0}")" && pwd)
+
+# Make a fake passwd file for the invoking user.
+#
+# This setup is so that files created from inside the container in a mounted
+# volume end up being owned by the invoking user and not by root.
+# We'll mount a fresh directory owned by the invoking user as /root inside the
+# container because the container needs a $HOME (without one the default is /)
+# and because various utilities (e.g. bash writing to .bash_history) need to be
+# able to write to there.
+username=$(id -un)
+uid_gid=$(id -u):$(id -g)
+container_root=${repo_root}/docker_root
+mkdir -p "${container_root}"/{etc,home}
+echo "${username}:x:${uid_gid}::/home/${username}:/bin/bash" > "${container_root}/etc/passwd"
+
+exec docker run \
+  --volume="${container_root}/etc/passwd:/etc/passwd" \
+  --volume="${container_root}/home/${username}:/home/${username}" \
+  --volume="${gopath0}/src:/home/${username}/go/src" \
+  --workdir="/home/${username}/go/src/github.com/cockroachdb/examples-orms" \
+  --env=PIP_USER=1 \
+  --env=GEM_HOME="/home/${username}/.gems" \
+  --user="${uid_gid}" \
+  "$image" \
+  "$@"


### PR DESCRIPTION
Run Docker as an unprivileged user instead of root by cargo-culting the
relevant pieces of cockroachdb/cockroach/build/builder.sh. Otherwise,
Docker litters the repo with directories owned by root. This is
particularly bad on TeamCity, where the build agent is permanently
bricked because its default `git clean` build step fails.

We worked around this by having TeamCity run `make dockergitclean` after
every examples-orm build, but this command would be skipped if a build
was canceled manually, leaving the build agent in a broken state.
Avoiding these root-owned directories entirely is a more robust
solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/23)
<!-- Reviewable:end -->
