### PR TITLE
rails: disable DDL transactions

### DIFF
--- a/ruby/activerecord/db/migrate/20170207160810_create_schema.rb
+++ b/ruby/activerecord/db/migrate/20170207160810_create_schema.rb
@@ -1,4 +1,5 @@
 class CreateSchema < ActiveRecord::Migration
+  disable_ddl_transaction!
   def change
     create_table :customers do |t|
       t.string :name, null: false

--- a/ruby/activerecord/db/schema.rb
+++ b/ruby/activerecord/db/schema.rb
@@ -20,16 +20,13 @@ ActiveRecord::Schema.define(version: 20170207160810) do
     t.bigint "order_id",   null: false
     t.bigint "product_id", null: false
     t.index ["order_id"], name: "index_order_products_on_order_id"
-    t.index ["order_id"], name: "order_products_auto_index_fk_rails_f40b8ccee4"
     t.index ["product_id"], name: "index_order_products_on_product_id"
-    t.index ["product_id"], name: "order_products_auto_index_fk_rails_96c0709f78"
   end
 
   create_table "orders", id: :bigint, default: -> { "unique_rowid()" }, force: :cascade do |t|
     t.decimal "subtotal",    null: false
     t.bigint  "customer_id", null: false
     t.index ["customer_id"], name: "index_orders_on_customer_id"
-    t.index ["customer_id"], name: "orders_auto_index_fk_rails_3dad120da9"
   end
 
   create_table "products", id: :bigint, default: -> { "unique_rowid()" }, force: :cascade do |t|


### PR DESCRIPTION
Due to https://github.com/cockroachdb/cockroach/issues/16182, the FK doesn't see the indexes if in same txn,
so, as seen in schema.rb diff, it creates diplicative indexes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-orms/27)
<!-- Reviewable:end -->
