### PR TITLE
Support assigning random ports to the appserver

### DIFF
--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -14,10 +14,11 @@
 # for names of contributors.
 
 ADDR ?= cockroachdb://root@localhost:26257/company_sqlalchemy?sslmode=disable
+APPSERVER_PORT ?= 6543
 
 .PHONY: start
 start:
-	ADDR=$(ADDR) ./server.py --port=6543
+	ADDR=$(ADDR) ./server.py --port=$(APPSERVER_PORT)
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
... to allow stressing the sqlalchemy test.
This commit adds a flag to the test framework for the appserver flag.
That flag is passed to the language-specific makefile, and only the
SQLAlchemy one has support for it.

cc @jordanlewis 