### PR TITLE
Fix Sequelize 4.x compatiblity

### DIFF
--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -16,38 +16,32 @@ if (process.env.ADDR === undefined) {
 module.exports.Customer = sequelize.define('customer', {
   name: DataTypes.STRING
 }, {
-  instanceMethods: {
-    // jsonObject returns an object that JSON.stringify can trivially
-    // convert into the JSON response the test driver expects.
-    jsonObject: function() {
-      return {
-        id: parseInt(this.id),
-        name: this.name
-      };
-    }
-  },
   timestamps: false
 });
+
+module.exports.customerToJSON = function(customer) {
+  return {
+    id: parseInt(this.id),
+    name: this.name
+  };
+};
 
 module.exports.Order = sequelize.define('order', {
   customer_id: DataTypes.INTEGER,
   subtotal: DataTypes.DECIMAL(18, 2)
 }, {
-  instanceMethods: {
-    // jsonObject returns an object that JSON.stringify can trivially
-    // convert into the JSON response the test driver expects.
-    jsonObject: function() {
-      return{
-        id: parseInt(this.id),
-        subtotal: this.subtotal,
-        customer: {
-          id: this.customer_id
-        }
-      };
-    }
-  },
   timestamps: false
 });
+
+module.exports.orderToJSON = function(order) {
+  return{
+    id: parseInt(order.id),
+    subtotal: order.subtotal,
+    customer: {
+      id: order.customer_id
+    }
+  };
+};
 
 module.exports.OrderProduct = sequelize.define('order_products', {
   order_id: {
@@ -66,19 +60,16 @@ module.exports.Product = sequelize.define('product', {
   name: DataTypes.STRING,
   price: DataTypes.DECIMAL(18, 2)
 }, {
-  instanceMethods: {
-    // jsonObject returns an object that JSON.stringify can trivially
-    // convert into the JSON response the test driver expects.
-    jsonObject: function() {
-      return {
-        id: parseInt(this.id),
-        name: this.name,
-        price: this.price,
-      };
-    }
-  },
   timestamps: false
 });
+
+module.exports.productToJSON = function(product) {
+  return {
+    id: parseInt(product.id),
+    name: product.name,
+    price: product.price,
+  };
+};
 
 module.exports.sequelize = sequelize;
 module.exports.Sequelize = Sequelize;

--- a/node/sequelize/routes/customer.js
+++ b/node/sequelize/routes/customer.js
@@ -5,7 +5,9 @@ var router = express.Router();
 // GET all customers.
 router.get('/', function(req, res, next) {
   models.Customer.findAll().then(function(customers) {
-    var result = customers.map(function(customer) { return customer.jsonObject(); });
+    var result = customers.map(function(customer) {
+      return models.customerToJSON(customer);
+    });
     res.json(result);
   }).catch(next);
 });
@@ -14,7 +16,7 @@ router.get('/', function(req, res, next) {
 router.post('/', function(req, res, next) {
   var c = {id: req.body.id, name: req.body.name};
   models.Customer.create(c).then(function(customer) {
-    res.json(customer.jsonObject());
+    res.json(models.customerToJSON(customer));
   }).catch(next);
 });
 
@@ -22,7 +24,7 @@ router.post('/', function(req, res, next) {
 router.get('/:id', function(req, res, next) {
   var id = parseInt(req.params.id);
   models.Customer.findById(id).then(function(customer) {
-    res.json(customer.jsonObject());
+    res.json(models.customerToJSON(customer));
   }).catch(next);
 });
 

--- a/node/sequelize/routes/order.js
+++ b/node/sequelize/routes/order.js
@@ -5,7 +5,9 @@ var router = express.Router();
 // GET all orders from database.
 router.get('/', function(req, res, next) {
   models.Order.findAll().then(function(orders) {
-    var result = orders.map(function(order) { return order.jsonObject(); });
+    var result = orders.map(function(order) {
+      return models.orderToJSON(order);
+    });
     res.json(result);
   }).catch(next);
 });
@@ -18,7 +20,7 @@ router.post('/', function(req, res, next) {
     customer_id: parseInt(req.body.customer.id)
   };
   models.Order.create(o).then(function(order) {
-    res.json(order.jsonObject());
+    res.json(models.orderToJSON(order));
   }).catch(next);
 });
 
@@ -26,7 +28,7 @@ router.post('/', function(req, res, next) {
 router.get('/:id', function(req, res, next) {
   var id = parseInt(req.params.id);
   models.Order.findById(id).then(function(order) {
-    res.json(order.jsonObject());
+    res.json(models.orderToJSON(order));
   }).catch(next);
 });
 

--- a/node/sequelize/routes/product.js
+++ b/node/sequelize/routes/product.js
@@ -5,7 +5,9 @@ var router = express.Router();
 // GET all products from database.
 router.get('/', function(req, res, next) {
   models.Product.findAll().then(function(products) {
-    var result = products.map(function(product) { return product.jsonObject(); });
+    var result = products.map(function(product) {
+      return models.productToJSON(product);
+    });
     res.json(result);
   }).catch(next);
 });
@@ -19,7 +21,7 @@ router.post('/', function(req, res, next) {
     price: parseFloat(req.body.price)
   };
   models.Product.create(p).then(function(product) {
-    res.json(product.jsonObject());
+    res.json(models.productToJSON(product));
   }).catch(next);
 });
 
@@ -27,7 +29,7 @@ router.post('/', function(req, res, next) {
 router.get('/:id', function(req, res, next) {
   var id = parseInt(req.params.id);
   models.Product.findById(id).then(function(product) {
-    res.json(product.jsonObject());
+    res.json(models.productToJSON(product));
   }).catch(next);
 });
 


### PR DESCRIPTION
Sequelize 4.x significantly changes its models. Among other things,
models are now full ES6 classes (before they were some object that
wasn't a class). Because of this, adding an instance method for
Sequelize 3.x objects is different from Sequelize 4.x.

The easiest way to resolve this was to convert the instance methods into
helper functions.

Tested with both Sequelize 3.30.2 and 4.2.1.