### PR TITLE
Single quote ADDR environment variable

### DIFF
--- a/go/gorm/Makefile
+++ b/go/gorm/Makefile
@@ -22,4 +22,4 @@ endif
 .PHONY: start
 start:
 	@go build
-	@./gorm $(ADDRFLAG)
+	@./gorm '$(ADDRFLAG)'


### PR DESCRIPTION
When multiple query params are used in the `ADDR` URI, they are
separated by an ampersand. So, when this URI passes through an env
var, it needs to be single quoted to avoid treating the ampersand
as a special character.

Fixes issue with https://github.com/cockroachdb/cockroach/pull/17602.