### PR TITLE
ruby/activerecord: bump puma to ipv6-compatible version

### DIFF
--- a/ruby/activerecord/Gemfile.lock
+++ b/ruby/activerecord/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     pg (0.21.0)
-    puma (3.9.1)
+    puma (3.10.0)
     rack (2.0.3)
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
Our new DigitalOcean TeamCity agents have IPv6 entries in /etc/hosts.
Puma couldn't handle this until v3.10.