### PR TITLE
Re-enable SQLAlchemyTest

### DIFF
--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -243,7 +243,6 @@ func TestSequelize(t *testing.T) {
 }
 
 func TestSQLAlchemy(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/16715")
 	testORM(t, "python", "sqlalchemy")
 }
 


### PR DESCRIPTION
I haven't been able to reproduce the SQLAlchemy flakiness locally.  I'd like to try turning the test back on to see if recent changes to the schema-management code have fixed this issue.

My test setup is as follows:

`go test -v -run TestSQLAlchemy -count 25  ./testing/ -cockroach-binary=/Users/bob/go/src/github.com/cockroachdb/cockroach/cockroach`

This was successful across repeated runs.  I've also tried running `stress -p 16 yes` to load the CPU on my test machine and haven't been able to reproduce a flake.