### PR TITLE
Moving the example-orms app to using its own, up-to-date builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:8
+
+RUN apt-get update -y
+
+RUN apt-get install -y zlib1g zlib1g-dev
+
+# installations for django
+RUN apt-get install -y python3 python3-dev python3-pip
+
+# installations for sqlalchemy
+RUN apt-get install -y python python-dev python-pip
+
+# installations for node
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt-get -y update
+
+RUN apt-get install -y nodejs
+
+# RUN apt-get install -y ruby-full
+
+RUN apt-get install -y postgresql postgresql-contrib libpq-dev git wget build-essential curl openssl
+
+# Installations for gradle and gradlew
+RUN apt-get install gradle -y
+
+# installations for golang
+RUN curl https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz -o golang.tar.gz \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+# installations for ruby
+RUN mkdir ruby-install && \
+	curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
+	make -C ruby-install install && \
+	ruby-install --system ruby 2.4.0 && \
+	gem update --system
+
+ENV PATH /usr/local/go/bin:$PATH

--- a/docker.sh
+++ b/docker.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-image=docker.io/cockroachdb/postgres-test:20190103-1358
+image=cockroachdb/example-orms-builder:latest
 
 gopath=$(go env GOPATH)
 gopath0=${gopath%%:*}
@@ -50,6 +50,7 @@ exec docker run \
   --workdir="/home/${username}/go/src/github.com/cockroachdb/examples-orms" \
   --env=PIP_USER=1 \
   --env=GEM_HOME="/home/${username}/.gems" \
+  --env=GOPATH="/home/${username}/go" \
   --user="${uid_gid}" \
   "$image" \
   "$@"

--- a/java/hibernate/Makefile
+++ b/java/hibernate/Makefile
@@ -30,4 +30,5 @@ start:
 
 .PHONY: deps
 deps:
+	gradle wrapper
 	$(GRADLE) assemble --stacktrace

--- a/python/django/Makefile
+++ b/python/django/Makefile
@@ -1,8 +1,8 @@
 .PHONY: start
 start:
-	./manage.py migrate cockroach_example && ./manage.py runserver 6543
+	python3 manage.py migrate cockroach_example && python3 manage.py runserver 6543
 
 deps:
 	git clone https://github.com/cockroachlabs/cockroach-django || true
-	cd cockroach-django && pip install .
-	python -m pip install "django<2"
+	cd cockroach-django && pip3 install .
+	pip3 install django

--- a/python/django/cockroach_example/settings.py
+++ b/python/django/cockroach_example/settings.py
@@ -12,8 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -23,4 +23,4 @@ start:
 deps:
 	# To avoid permissions errors, the following should be run in a virtualenv
 	# (preferred) or as root.
-	pip install flask-sqlalchemy cockroachdb
+	pip install flask-sqlalchemy cockroachdb psycopg2

--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -249,9 +249,9 @@ func TestSQLAlchemy(t *testing.T) {
 	testORM(t, "python", "sqlalchemy", defaultTestTableNames, defaultTestColumnNames)
 }
 
-// func TestDjango(t *testing.T) {
-// 	testORM(t, "python", "django", djangoTestTableNames, djangoTestColumnNames)
-// }
+func TestDjango(t *testing.T) {
+	testORM(t, "python", "django", djangoTestTableNames, djangoTestColumnNames)
+}
 
 func TestActiveRecord(t *testing.T) {
 	testORM(t, "ruby", "activerecord", defaultTestTableNames, defaultTestColumnNames)


### PR DESCRIPTION
This PR replaces the docker.sh build file to instead use a different
Dockerfile that is more up to date than the postgres-test image, and
updates some of the test apps build configurations to run with newer
packages.