### PR TITLE
Skip TestDjango due to v2.1 failures

### DIFF
--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -250,6 +250,7 @@ func TestSQLAlchemy(t *testing.T) {
 }
 
 func TestDjango(t *testing.T) {
+	t.Skip("TestDjango fails on CRDB v2.1; github.com/cockroachdb/cockroach/issues/42083")
 	testORM(t, "python", "django", djangoTestTableNames, djangoTestColumnNames)
 }
 


### PR DESCRIPTION
TestDjango fails on v2.1. Skipping the test while https://github.com/cockroachdb/examples-orms/issues/82 is resolved.