### PR TITLE
django: disable installation steps for django

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,5 @@ deps:
 	$(MAKE) deps -C ./python/sqlalchemy
 	$(MAKE) deps -C ./ruby/activerecord
 	$(MAKE) deps -C ./ruby/ar4
-	$(MAKE) deps -C ./python/django
+	# Django test is disabled for now.
+	# $(MAKE) deps -C ./python/django


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/42559.

Due to versions not being pinned, there are alot of transient issues with the django test.