### PR TITLE
Enable testing against Django

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8
+FROM openjdk:8-slim-buster
 
 RUN apt-get update -y
 
-RUN apt-get install -y zlib1g zlib1g-dev
+RUN apt-get install -y zlib1g zlib1g-dev curl wget apt-utils
 
 # installations for django
 RUN apt-get install -y python3 python3-dev python3-pip
@@ -17,7 +17,7 @@ RUN apt-get install -y nodejs
 
 # RUN apt-get install -y ruby-full
 
-RUN apt-get install -y postgresql postgresql-contrib libpq-dev git wget build-essential curl openssl
+RUN apt-get install -y postgresql postgresql-contrib libpq-dev git build-essential openssl
 
 # Installations for gradle and gradlew
 RUN apt-get install gradle -y

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,4 @@ deps:
 	$(MAKE) deps -C ./python/sqlalchemy
 	$(MAKE) deps -C ./ruby/activerecord
 	$(MAKE) deps -C ./ruby/ar4
-	# Django test is disabled for now.
-	# $(MAKE) deps -C ./python/django
+	$(MAKE) deps -C ./python/django

--- a/docker.sh
+++ b/docker.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-image=cockroachdb/example-orms-builder:latest
+image=cockroachdb/example-orms-builder:20200129-1444
 
 gopath=$(go env GOPATH)
 gopath0=${gopath%%:*}

--- a/python/django/Makefile
+++ b/python/django/Makefile
@@ -3,6 +3,7 @@ start:
 	python3 manage.py migrate cockroach_example && python3 manage.py runserver 6543
 
 deps:
-	git clone https://github.com/cockroachlabs/cockroach-django || true
-	cd cockroach-django && pip3 install .
+	git clone https://github.com/cockroachdb/django-cockroachdb || true
+	pip3 install --upgrade setuptools
 	pip3 install django
+	cd django-cockroachdb && pip3 install .

--- a/ruby/activerecord/Makefile
+++ b/ruby/activerecord/Makefile
@@ -24,5 +24,5 @@ start:
 
 .PHONY: deps
 deps:
-	@gem install bundler
+	@gem install bundler:1.15.1
 	@bin/bundle


### PR DESCRIPTION
Now that django-cockroachdb has been released, tests should be more
stable.

The docker image version is now specified with a timestamp, as opposed
to always using "latest." This makes it easier to update and revert to
older images.

closes #87