### PR TITLE
Update the name of the SQLAlchemy adapter

### DIFF
--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -23,4 +23,4 @@ start:
 deps:
 	# To avoid permissions errors, the following should be run in a virtualenv
 	# (preferred) or as root.
-	pip install flask-sqlalchemy cockroachdb psycopg2
+	pip install flask-sqlalchemy sqlalchemy-cockroachdb psycopg2


### PR DESCRIPTION
It is now published in pypi as sqlalchemy-cockroachdb