### PR TITLE
Explicitly install psycopg2 in Django test

### DIFF
--- a/python/django/Makefile
+++ b/python/django/Makefile
@@ -5,5 +5,5 @@ start:
 deps:
 	git clone https://github.com/cockroachdb/django-cockroachdb || true
 	pip3 install --upgrade setuptools
-	pip3 install django
+	pip3 install django psycopg2
 	cd django-cockroachdb && pip3 install .


### PR DESCRIPTION
The django-cockroachdb adapter was recently changed to require psycopg2
to be installed explicitly.

see https://github.com/cockroachdb/django-cockroachdb/pull/130