### PR TITLE
Use python3 for sqlalchemy tests

### DIFF
--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -17,10 +17,10 @@ ADDR ?= cockroachdb://root@localhost:26257/company_sqlalchemy?sslmode=disable
 
 .PHONY: start
 start:
-	ADDR=$(ADDR) ./server.py --port=6543
+	ADDR=$(ADDR) python3 ./server.py --port=6543
 
 .PHONY: deps
 deps:
 	# To avoid permissions errors, the following should be run in a virtualenv
 	# (preferred) or as root.
-	pip install flask-sqlalchemy sqlalchemy-cockroachdb psycopg2
+	pip3 install flask-sqlalchemy sqlalchemy-cockroachdb psycopg2


### PR DESCRIPTION
Our sqlalchemy adapter no longer supports python2.