### PR TITLE
Skip Activerecord tests for <=v19.1

### DIFF
--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -157,8 +157,12 @@ func testORM(
 	db, dbURL, version, stopDB := initTestDatabase(t, app)
 	defer stopDB()
 
-	if orm == "django"  && (strings.HasPrefix(version, "v2.0") || strings.HasPrefix(version, "v2.1")) {
+	if orm == "django" && (strings.HasPrefix(version, "v2.0") || strings.HasPrefix(version, "v2.1")) {
 		t.Skip("TestDjango fails on CRDB <=v2.1 due to missing foreign key support.")
+	}
+
+	if orm == "activerecord" && (strings.HasPrefix(version, "v2.") || strings.HasPrefix(version, "v19.1")) {
+		t.Skip("TestActiveRecord fails on CRDB <=v19.1 due to missing pg_catalog support.")
 	}
 
 	td := testDriver{


### PR DESCRIPTION
See: https://github.com/cockroachdb/cockroach/issues/50464

These are failing currently because of missing pg_catalog tables.

We'll skip the test for versions <=19.1 until we can debug the underlying issue.
(Note, we may decide to leave the skipped test permanently, as our [tooling
support page](https://www.cockroachlabs.com/docs/stable/third-party-database-tools.html) specifies that we support ActiveRecord for CockroachDB 20.1+.)