### PR TITLE
Pin Python dependency versions

### DIFF
--- a/python/django/Makefile
+++ b/python/django/Makefile
@@ -3,7 +3,5 @@ start:
 	python3 manage.py migrate cockroach_example && python3 manage.py runserver 6543
 
 deps:
-	git clone https://github.com/cockroachdb/django-cockroachdb || true
 	pip3 install --upgrade setuptools
-	pip3 install django psycopg2
-	cd django-cockroachdb && pip3 install .
+	pip3 install django==3.0.9 django-cockroachdb==3.0.1 psycopg2

--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -23,4 +23,4 @@ start:
 deps:
 	# To avoid permissions errors, the following should be run in a virtualenv
 	# (preferred) or as root.
-	pip3 install flask-sqlalchemy sqlalchemy-cockroachdb psycopg2
+	pip3 install flask-sqlalchemy==2.4.4 sqlalchemy-cockroachdb==1.3.1 psycopg2


### PR DESCRIPTION
The build started failing because a new Django release happened, and
that release is not compatible with our current django adapter.