### PR TITLE
Check for null in unstable field of cluster version

### DIFF
--- a/testing/main_test.go
+++ b/testing/main_test.go
@@ -249,7 +249,7 @@ func testORM(t *testing.T, info testInfo) {
 		var tenantsSupported bool
 		if err := db.QueryRow(`
 SELECT
-	(major = 20 AND minor = 1 AND unstable > 17)
+    (major = 20 AND minor = 1 AND (unstable IS NOT NULL AND unstable > 17))
 	OR (major = 20 AND minor > 1)
 	OR (major > 20)
 FROM


### PR DESCRIPTION
The release-20.1 branch had a NULL unstable field, which caused this
version check query to return NULL, instead of a true/false bool.