### PR TITLE
Update cockroach-go version to v2.2.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cockroachdb/examples-orms
 go 1.13
 
 require (
-	github.com/cockroachdb/cockroach-go/v2 v2.2.13
+	github.com/cockroachdb/cockroach-go/v2 v2.2.15
 	github.com/go-pg/pg/v10 v10.9.0
 	github.com/julienschmidt/httprouter v1.1.0
 	github.com/lib/pq v1.10.6

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/cockroachdb/cockroach-go/v2 v2.2.13 h1:IsQmOtHQrfv0v3AqIEv+mStB09amzbH8gDDyVcpl3xQ=
-github.com/cockroachdb/cockroach-go/v2 v2.2.13/go.mod h1:xZ2VHjUEb/cySv0scXBx7YsBnHtLHkR1+w/w73b5i3M=
+github.com/cockroachdb/cockroach-go/v2 v2.2.15 h1:6TeTC1JLSlHJWJCswWZ7mQyT16kY5mQSs53C2coQISI=
+github.com/cockroachdb/cockroach-go/v2 v2.2.15/go.mod h1:xZ2VHjUEb/cySv0scXBx7YsBnHtLHkR1+w/w73b5i3M=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=


### PR DESCRIPTION
This will pull in the changes to dynamically check for the
availability of tenant scoped client certs for running the
multitenant tests. The availability of these tenant scoped
client certificates was previously only available in hardcoded
versions of cockroachdb, but now we check for it dynamically
to make backporting these tenant scoped client certs easier.

Tenant scoped client certificates are required for example-orm
tests to run successfuly with cockroachdb versions using tenant
scoped client certificates in the multitenant architecture.