### PR TITLE
pin sqlalchemy dep to 1.4.46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cockroachdb/examples-orms
 go 1.13
 
 require (
-	github.com/cockroachdb/cockroach-go/v2 v2.2.15
+	github.com/cockroachdb/cockroach-go/v2 v2.2.20
 	github.com/go-pg/pg/v10 v10.9.0
 	github.com/julienschmidt/httprouter v1.1.0
 	github.com/lib/pq v1.10.6

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go/v2 v2.2.15 h1:6TeTC1JLSlHJWJCswWZ7mQyT16kY5mQSs53C2coQISI=
 github.com/cockroachdb/cockroach-go/v2 v2.2.15/go.mod h1:xZ2VHjUEb/cySv0scXBx7YsBnHtLHkR1+w/w73b5i3M=
+github.com/cockroachdb/cockroach-go/v2 v2.2.20 h1:TLSzwdTdIwgsbdApHzaxunhSMrmbGf5YY6oxtaP2kvw=
+github.com/cockroachdb/cockroach-go/v2 v2.2.20/go.mod h1:73vQi5H/H7kE8SgOt+XA6729Tubvj5hxKIEgbQQhp4c=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=

--- a/python/sqlalchemy/Makefile
+++ b/python/sqlalchemy/Makefile
@@ -23,4 +23,4 @@ start:
 deps:
 	# To avoid permissions errors, the following should be run in a virtualenv
 	# (preferred) or as root.
-	pip3 install flask-sqlalchemy==2.5.1 sqlalchemy-cockroachdb==1.4.1 psycopg2
+	pip3 install flask-sqlalchemy==2.5.1 sqlalchemy-cockroachdb==1.4.1 psycopg2 sqlalchemy==1.4.46


### PR DESCRIPTION
Fixes compiler errors coinciding with the release of [v2.0.0](https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_2_0_0).